### PR TITLE
add field 'itemTypeEN' to use English item type name in rename rule (…

### DIFF
--- a/chrome/content/zotfile/wildcards.js
+++ b/chrome/content/zotfile/wildcards.js
@@ -213,6 +213,7 @@ Zotero.ZotFile.Wildcards = new function() {
         var authors = formatAuthors(item);
         // define additional fields
         var addFields = {
+            'itemTypeEN': Zotero.ItemTypes.getName(item_type),
             'itemType': Zotero.ItemTypes.getLocalizedString(item_type),
             'titleFormated': truncateTitle(item.getField("title", false, true)),
             'author': authors[0],


### PR DESCRIPTION
…#562)